### PR TITLE
Fix size of bytes in write, use bytes from register, not from endpoint

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -145,7 +145,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>3.8.1</version>
+            <version>4.12</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/main/java/me/legrange/panstamp/NumberEndpoint.java
+++ b/src/main/java/me/legrange/panstamp/NumberEndpoint.java
@@ -42,9 +42,14 @@ final class NumberEndpoint extends AbstractEndpoint<Double> {
            value = (value - unit.getOffset()) / unit.getFactor();
         }
         long val = value.longValue();
-        byte bytes[] = new byte[epDef.getSize().getBytes()];
+        byte bytes[];
+        if (reg.hasValue()) {
+            bytes = reg.getValue();
+        } else {
+            bytes = new byte[epDef.getRegister().getByteSize()];
+        }
         for (int i = epDef.getSize().getBytes() - 1; i >= 0; --i) {
-            bytes[i] = (byte) (val & 0xFF);
+            bytes[epDef.getPosition().getBytePos() + i] = (byte) (val & 0xFF);
             val = val >>> 8;
         }
         reg.setValue(bytes);

--- a/src/main/java/me/legrange/panstamp/PanStamp.java
+++ b/src/main/java/me/legrange/panstamp/PanStamp.java
@@ -303,8 +303,10 @@ public final class PanStamp {
 
     /**
      * send a query message to the remote node
+     * @param id register
+     * @throws ModemException
      */
-    void sendQueryMessage(int id) throws ModemException {
+    public void sendQueryMessage(int id) throws ModemException {
         nw.sendQueryMessage(this, id);
     }
 

--- a/src/test/java/panstamp/TestDeviceLibrary.java
+++ b/src/test/java/panstamp/TestDeviceLibrary.java
@@ -1,0 +1,62 @@
+package panstamp;
+
+import static org.junit.Assert.*;
+
+import java.io.File;
+
+import org.junit.Test;
+
+import me.legrange.panstamp.DeviceLibrary;
+import me.legrange.panstamp.NetworkException;
+import me.legrange.panstamp.definition.CompoundDeviceLibrary;
+import me.legrange.panstamp.definition.DeviceDefinition;
+import me.legrange.panstamp.xml.ClassLoaderLibrary;
+import me.legrange.panstamp.xml.FileLibrary;
+
+/**
+ * Basic Tests for the Device Library
+ * @author Mathias
+ *
+ */
+public class TestDeviceLibrary {
+
+	/**
+	 * Load and test default device definition library.
+     * @throws NetworkException
+	 */
+    @Test
+    public void testDefault() throws NetworkException {
+        DeviceLibrary devLib = new ClassLoaderLibrary();
+        testInternal(devLib);
+    }
+
+    /**
+     * Load and test device with a given path definition library.
+     * Might be used to check changes in device definition files.
+     * @throws NetworkException
+     */
+    @Test
+    public void testCustom() throws NetworkException {
+        String dir = "src/main/resources/devices";
+        FileLibrary lib = new FileLibrary(new File(dir));
+        assertNotNull(lib);
+        DeviceLibrary devLib = new CompoundDeviceLibrary(lib, new ClassLoaderLibrary());
+        testInternal(devLib);
+    }
+
+    /**
+     * Run some tests with an given device library
+     *
+     * @param devLib device library, might be null
+     * @throws NetworkException
+     */
+    private void testInternal(DeviceLibrary devLib) throws NetworkException {
+        assertNotNull(devLib);
+        // Manufacture 1 = panStamp, Product 1 = Dual Temperature-Humidity sensor
+        assertTrue(devLib.hasDeviceDefinition(1, 1));
+        DeviceDefinition devDef = devLib.getDeviceDefinition(1, 1);
+        assertNotNull(devDef);
+        System.out.println(" Device definition = " + devDef);
+    }
+
+}


### PR DESCRIPTION
Dear Gideon,

I fixed a bug in the NumberEndpoint. If there are more than one Endpoints in a register, the size of the byte Array is wrong in the write Method.
Ich extended the code similar to the IntegerEndpoint and take the bytes from the register and not from the endpoint.

Best Regards

  Mathias

By the way, I have an extension for the panstamp-tools library, a Get value (query) similar to Set value. If you like I can send you the code fragment or create a pull request
